### PR TITLE
made findByName query case insensitive

### DIFF
--- a/app/cotw-mdb.js
+++ b/app/cotw-mdb.js
@@ -31,7 +31,7 @@ const getCategories = async () => {
 };
 
 const findByName = async (recipeName) => {
-  const queriedRecipe = await Recipe.findOne({ name: recipeName });
+  const queriedRecipe = await Recipe.findOne({ name: { $regex: recipeName, $options: 'i'}});
   return queriedRecipe;
 };
 


### PR DESCRIPTION
Adding regex and options parameters to the findOne appears to have fixed this.